### PR TITLE
Don't run when non-interactive

### DIFF
--- a/fish-apple-touchbar.fish
+++ b/fish-apple-touchbar.fish
@@ -1,29 +1,31 @@
 function fish-apple-touchbar
-    function __fish_apple_touchbar_first_view
-        function bind_keys_function
-            __fish_apple_touchbar_bind_key 1 '👉 pwd' "pwd" '-s'
-            __fish_apple_touchbar_bind_key 2 'second view' '__fish_apple_touchbar_second_view'
-            __fish_apple_touchbar_bind_key 3 'third view' '__fish_apple_touchbar_third_view'
+    if status is-interactive
+        function __fish_apple_touchbar_first_view
+            function bind_keys_function
+                __fish_apple_touchbar_bind_key 1 '👉 pwd' "pwd" '-s'
+                __fish_apple_touchbar_bind_key 2 'second view' '__fish_apple_touchbar_second_view'
+                __fish_apple_touchbar_bind_key 3 'third view' '__fish_apple_touchbar_third_view'
+            end
+
+            __fish_apple_touchbar_create_view 'first' bind_keys_function
         end
 
-        __fish_apple_touchbar_create_view 'first' bind_keys_function
-    end
+        function __fish_apple_touchbar_second_view
+            function bind_keys_function
+                __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
+                __fish_apple_touchbar_bind_key 2 'current path' "pwd" '-s'
+            end
 
-    function __fish_apple_touchbar_second_view
-        function bind_keys_function
-            __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
-            __fish_apple_touchbar_bind_key 2 'current path' "pwd" '-s'
+            __fish_apple_touchbar_create_view 'second' bind_keys_function
         end
 
-        __fish_apple_touchbar_create_view 'second' bind_keys_function
-    end
+        function __fish_apple_touchbar_third_view
+            function bind_keys_function
+                __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
+                __fish_apple_touchbar_bind_key 2 'ls' "ls -la" '-s'
+            end
 
-    function __fish_apple_touchbar_third_view
-        function bind_keys_function
-            __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
-            __fish_apple_touchbar_bind_key 2 'ls' "ls -la" '-s'
+            __fish_apple_touchbar_create_view 'third' bind_keys_function
         end
-
-        __fish_apple_touchbar_create_view 'third' bind_keys_function
     end
 end

--- a/fish-apple-touchbar.fish
+++ b/fish-apple-touchbar.fish
@@ -1,31 +1,32 @@
 function fish-apple-touchbar
     if status is-interactive
-        function __fish_apple_touchbar_first_view
-            function bind_keys_function
-                __fish_apple_touchbar_bind_key 1 '👉 pwd' "pwd" '-s'
-                __fish_apple_touchbar_bind_key 2 'second view' '__fish_apple_touchbar_second_view'
-                __fish_apple_touchbar_bind_key 3 'third view' '__fish_apple_touchbar_third_view'
-            end
-
-            __fish_apple_touchbar_create_view 'first' bind_keys_function
+        exit 0
+    end
+    function __fish_apple_touchbar_first_view
+        function bind_keys_function
+            __fish_apple_touchbar_bind_key 1 '👉 pwd' "pwd" '-s'
+            __fish_apple_touchbar_bind_key 2 'second view' '__fish_apple_touchbar_second_view'
+            __fish_apple_touchbar_bind_key 3 'third view' '__fish_apple_touchbar_third_view'
         end
 
-        function __fish_apple_touchbar_second_view
-            function bind_keys_function
-                __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
-                __fish_apple_touchbar_bind_key 2 'current path' "pwd" '-s'
-            end
+        __fish_apple_touchbar_create_view 'first' bind_keys_function
+    end
 
-            __fish_apple_touchbar_create_view 'second' bind_keys_function
+    function __fish_apple_touchbar_second_view
+        function bind_keys_function
+            __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
+            __fish_apple_touchbar_bind_key 2 'current path' "pwd" '-s'
         end
 
-        function __fish_apple_touchbar_third_view
-            function bind_keys_function
-                __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
-                __fish_apple_touchbar_bind_key 2 'ls' "ls -la" '-s'
-            end
+        __fish_apple_touchbar_create_view 'second' bind_keys_function
+    end
 
-            __fish_apple_touchbar_create_view 'third' bind_keys_function
+    function __fish_apple_touchbar_third_view
+        function bind_keys_function
+            __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
+            __fish_apple_touchbar_bind_key 2 'ls' "ls -la" '-s'
         end
+
+        __fish_apple_touchbar_create_view 'third' bind_keys_function
     end
 end

--- a/fish-apple-touchbar.fish
+++ b/fish-apple-touchbar.fish
@@ -1,5 +1,5 @@
 function fish-apple-touchbar
-    if status is-interactive
+    if not status is-interactive
         exit 0
     end
     function __fish_apple_touchbar_first_view


### PR DESCRIPTION
Running this script in non-interactive shell (such as fish_config) causes problems. Since you don't need this in a non-interactive shell, it's safe to just avoid running the whole thing.