### PR TITLE
add check and escape sequence for tmux

### DIFF
--- a/functions/__fish_apple_touchbar_print_key.fish
+++ b/functions/__fish_apple_touchbar_print_key.fish
@@ -1,3 +1,7 @@
 function __fish_apple_touchbar_print_key --argument-names cmd
-    echo -ne "\033]1337;$cmd\a"
+    set template "\e]1337;%s\a"
+    if test -n "$TMUX"
+        set template "\ePtmux;\e$template\e\\"
+    end
+    printf $template "$cmd"
 end

--- a/functions/__fish_apple_touchbar_print_key.fish
+++ b/functions/__fish_apple_touchbar_print_key.fish
@@ -1,6 +1,6 @@
 function __fish_apple_touchbar_print_key --argument-names cmd
     set template "\e]1337;%s\a"
-    if test -n "$TMUX"
+    if test -n "$TMUX"; or match string "tmux*" "$TERM"
         set template "\ePtmux;\e$template\e\\"
     end
     printf $template "$cmd"


### PR DESCRIPTION
Found another issue when testing on my machine - when running fish in tmux, the plugin does not work. Reason for this is that we first need to escape tmux.
This PR implements exactly that; it checks if `$TMUX` is set, and if it is, it adds the appropriate escape sequences.

Tested by starting a new shell in tmux and outside of tmux. e.g.:
1) Start a tmux session (`tmux new -s test`)
2) check that the plugin still works
3) exit tmux session / open new iterm window
4) check that plugin still works

Solution has basically been adapted from [here](https://github.com/docwhat/dotfiles/blob/master/zsh/startup/iterm.zsh#L10)