### PR TITLE
fix check for tumx

### DIFF
--- a/functions/__fish_apple_touchbar_print_key.fish
+++ b/functions/__fish_apple_touchbar_print_key.fish
@@ -1,6 +1,6 @@
 function __fish_apple_touchbar_print_key --argument-names cmd
     set template "\e]1337;%s\a"
-    if test -n "$TMUX"; or match string "tmux*" "$TERM"
+    if test -n "$TMUX"; or string match "tmux*" "$TERM"
         set template "\ePtmux;\e$template\e\\"
     end
     printf $template "$cmd"


### PR DESCRIPTION
Hi again,

Seems like something slipped through my testing, sorry for that.

This PR fixes a bug - obviously it should be `string match`, and not `match string`...fish is going to complain heavily on startup.

Thanks 🙂 