### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@
 
 1. Install with [Fisher](https://github.com/jorgebucaran/fisher)
 
-   Fisher v3
-
    ```console
    fisher install rodrigobdz/fish-apple-touchbar
    ```

--- a/README.md
+++ b/README.md
@@ -18,18 +18,12 @@
 
    ![function keys touchbar](./assets/iterm2-touchbar-function-module.png)
 
-1. Install Fisher package
+1. Install with [Fisher](https://github.com/jorgebucaran/fisher)
 
    Fisher v3
 
-   ```sh
-   fisher add rodrigobdz/fish-apple-touchbar
-   ```
-   
-   Fisher v2
-   
-   ```sh
-   fisher rodrigobdz/fish-apple-touchbar
+   ```console
+   fisher install rodrigobdz/fish-apple-touchbar
    ```
 
 1. Open a new terminal session to activate the package


### PR DESCRIPTION
`add` was renamed to `fisher install` in [`4.x`](https://github.com/jorgebucaran/fisher/releases/tag/4.0.0). Also removed instructions from older unsupported Fisher versions.