### PR TITLE
Fix key bindings when vi mode is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed fisher install and uninstall event triggers
-- Fixed fisher's [deprecation](https://github.com/jorgebucaran/fisher/issues/651) notice
+- [Fixed](https://github.com/rodrigobdz/fish-apple-touchbar/issues/10) fisher's [deprecation](https://github.com/jorgebucaran/fisher/issues/651) notice
+- [Fixed](https://github.com/rodrigobdz/fish-apple-touchbar/issues/7) key bindings when vi mode is not enabled
 
 ## [Unreleased]
 

--- a/functions/__fish_apple_touchbar_bind_key.fish
+++ b/functions/__fish_apple_touchbar_bind_key.fish
@@ -1,7 +1,7 @@
 function __fish_apple_touchbar_bind_key --argument-names fn_number fn_text fn_command bind_option
     __fish_apple_touchbar_print_key "SetKeyLabel=F$fn_number=$fn_text"
 
-    if bind -M insert >/dev/null 2>&1
+    if test "$fish_key_bindings" = fish_vi_key_bindings
         set vimbind "-M" "insert"
     end
 

--- a/functions/__fish_apple_touchbar_bind_key.fish
+++ b/functions/__fish_apple_touchbar_bind_key.fish
@@ -2,7 +2,7 @@ function __fish_apple_touchbar_bind_key --argument-names fn_number fn_text fn_co
     __fish_apple_touchbar_print_key "SetKeyLabel=F$fn_number=$fn_text"
 
     if test "$fish_key_bindings" = fish_vi_key_bindings
-        set vimbind "-M" "insert"
+        set vimbind "--mode" "insert"
     end
 
     if [ "$bind_option" = "-s" ]

--- a/functions/fish-apple-touchbar.fish
+++ b/functions/fish-apple-touchbar.fish
@@ -3,30 +3,30 @@ function fish-apple-touchbar
         exit 0
     end
     function __fish_apple_touchbar_first_view
-        function bind_keys_function
+        function _bind_keys_function_1
             __fish_apple_touchbar_bind_key 1 '👉 pwd' "pwd" '-s'
             __fish_apple_touchbar_bind_key 2 'second view' '__fish_apple_touchbar_second_view'
             __fish_apple_touchbar_bind_key 3 'third view' '__fish_apple_touchbar_third_view'
         end
 
-        __fish_apple_touchbar_create_view 'first' bind_keys_function
+        __fish_apple_touchbar_create_view 'first' _bind_keys_function_1
     end
 
     function __fish_apple_touchbar_second_view
-        function bind_keys_function
+        function _bind_keys_function_2
             __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
             __fish_apple_touchbar_bind_key 2 'current path' "pwd" '-s'
         end
 
-        __fish_apple_touchbar_create_view 'second' bind_keys_function
+        __fish_apple_touchbar_create_view 'second' _bind_keys_function_2
     end
 
     function __fish_apple_touchbar_third_view
-        function bind_keys_function
+        function _bind_keys_function_3
             __fish_apple_touchbar_bind_key 1 '👈 back' '__fish_apple_touchbar_first_view'
             __fish_apple_touchbar_bind_key 2 'ls' "ls -la" '-s'
         end
 
-        __fish_apple_touchbar_create_view 'third' bind_keys_function
+        __fish_apple_touchbar_create_view 'third' _bind_keys_function_3
     end
 end


### PR DESCRIPTION
Fixes https://github.com/rodrigobdz/fish-apple-touchbar/issues/3 and https://github.com/rodrigobdz/fish-apple-touchbar/issues/7.