### PR TITLE
Functions: don't display osascript call

### DIFF
--- a/functions/__fish_apple_touchbar_bind_key.fish
+++ b/functions/__fish_apple_touchbar_bind_key.fish
@@ -12,6 +12,7 @@ function __fish_apple_touchbar_bind_key --argument-names fn_number fn_text fn_co
         end
 	
 	bind $vimbind --key f$fn_number "commandline --replace '$fn_command'; commandline --function execute"
+	return
     end
     
     bind --key f$fn_number $fn_command

--- a/functions/__fish_apple_touchbar_bind_key.fish
+++ b/functions/__fish_apple_touchbar_bind_key.fish
@@ -6,7 +6,11 @@ function __fish_apple_touchbar_bind_key --argument-names fn_number fn_text fn_co
     end
 
     if [ "$bind_option" = "-s" ]
-        bind $vimbind --key f$fn_number "commandline --replace '$fn_command'; commandline --function execute"
+        if string match -q -- "*osascript*" "$fn_command"
+	    bind $vimbind --key f$fn_number "eval ($fn_command)"
+        else
+            bind $vimbind --key f$fn_number "commandline --replace '$fn_command'; commandline --function execute"
+        end
     else
         bind --key f$fn_number $fn_command
     end

--- a/functions/__fish_apple_touchbar_bind_key.fish
+++ b/functions/__fish_apple_touchbar_bind_key.fish
@@ -6,12 +6,13 @@ function __fish_apple_touchbar_bind_key --argument-names fn_number fn_text fn_co
     end
 
     if [ "$bind_option" = "-s" ]
-        if string match -q -- "*osascript*" "$fn_command"
+        if string match --quiet -- "*osascript*" "$fn_command"
 	    bind $vimbind --key f$fn_number "eval ($fn_command)"
-        else
-            bind $vimbind --key f$fn_number "commandline --replace '$fn_command'; commandline --function execute"
+	    return
         end
-    else
-        bind --key f$fn_number $fn_command
+	
+	bind $vimbind --key f$fn_number "commandline --replace '$fn_command'; commandline --function execute"
     end
+    
+    bind --key f$fn_number $fn_command
 end


### PR DESCRIPTION
I've been using this for quite few weeks now. What do you think?

I use it to split the terminal with one key, like so:

```fish
__fish_apple_touchbar_bind_key 7 '╂ split' 'osascript -e "tell application \"System Events\" to key code 2 using command down"' '-s'
```

https://github.com/fredericrous/dotfiles/blob/main/private_dot_config/private_fish/conf.d/touchbar.fish#L7
