### PR TITLE
Remove unnecessary `basename` and `awk` call

### DIFF
--- a/conf.d/fish_apple_touchbar.fish
+++ b/conf.d/fish_apple_touchbar.fish
@@ -2,17 +2,11 @@
 # Source: https://github.com/jorgebucaran/fisher/issues/651#issuecomment-762808325
 fish-apple-touchbar
 
-# Expected value should be fish_apple_touchbar_install
-set --local plugin_name_install (basename (status --current-filename) .fish)_install
-
-# Expected value should be fish_apple_touchbar_uninstall
-set --local plugin_name_uninstall (basename (status --current-filename) .fish)_uninstall
-
-function __fish_apple_touchbar_install --on-event "$plugin_name_install"
+function __fish_apple_touchbar_install --on-event "fish_apple_touchbar_install"
     __fish_apple_touchbar_first_view
 end
 
-function __fish_apple_touchbar_uninstall --on-event "$plugin_name_uninstall"
+function __fish_apple_touchbar_uninstall --on-event "fish_apple_touchbar_uninstall"
     __fish_apple_touchbar_reset_bindings
-    functions --erase (functions --all | command awk '/^__fish_apple_touchbar/')
+    functions --erase (functions --all | string match --regex --entire '^__fish_apple_touchbar')
 end

--- a/functions/fish-apple-touchbar.fish
+++ b/functions/fish-apple-touchbar.fish
@@ -1,6 +1,6 @@
 function fish-apple-touchbar
     if not status is-interactive
-        exit 0
+        return 0
     end
     function __fish_apple_touchbar_first_view
         function _bind_keys_function_1


### PR DESCRIPTION
It doesn't make sense to call `basename` if it is a fixed string. Plus it will slow down shell startup time a bit.

Also replaced `awk` call with `string match` to reduce external dependencies. This builtin dates back to pre-3.0 version of Fish so compatibility should not be an issue.

I also threw in a change that I don't feel like making a separate PR (but I'd like to if requested): replace `exit` in `return` in `fish-apple-touchbar` function. Therefore innocent scripts that call this function in non-interactive sessions won't exit accidentally.